### PR TITLE
Improved SPARQL query, application logics and information for the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Navigate to project folder and run following commands in the terminal:
 
 `pip install -r requirements.txt`
 
-`python -m spacy download en_core_web_sm`
+`python -m spacy download en_core_web_sm --default-timeout=50000`
+
+*Note:* Sometimes spacy has download issues. Therefore, increasing the timeout is recommended.
 
 ## Status of the project
 
-Currently system can answer only questions related to intent "How many inhabitants are living in the city X?". To be extended...
+Currently system can answer only questions related to intent "How many people live in X?" (where X is a city name). To be extended ...

--- a/app.py
+++ b/app.py
@@ -1,13 +1,13 @@
 from flask import Flask, render_template, request, flash, session, url_for, redirect, make_response
 from passlib.hash import sha256_crypt
-from datetime import timedelta
+from datetime import timedelta, datetime
 import requests
 from SPARQLWrapper import SPARQLWrapper, JSON
 import spacy
 
 nlp = spacy.load("en_core_web_sm")
 app = Flask(__name__)
-app.secret_key = '12345678'
+app.secret_key = str(datetime.now().time())
 
 def get_cities_for_a_text(text):
     doc = nlp(text)

--- a/app.py
+++ b/app.py
@@ -35,16 +35,18 @@ def get_answer():
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
         PREFIX dbo: <http://dbpedia.org/ontology/>
-        SELECT ?cityLabel ?numberOfInhabitants
-                where {
-                 ?s rdf:type dbo:City .
+        PREFIX yago: <http://dbpedia.org/class/yago/>
+        SELECT DISTINCT ?cityLabel ?numberOfInhabitants
+        WHERE {
+                 VALUES ?placeType { dbo:City yago:City108524735 }
+                 ?s rdf:type ?placeType .
                  ?s rdfs:label ?cityLabel .
                  filter(contains(lcase(?cityLabel),"%s")) .
                  filter(LANG(?cityLabel) = "en") .
                  ?s dbo:populationTotal ?numberOfInhabitants .  
         }
         ORDER BY DESC (?numberOfInhabitants)
-        LIMIT 10
+        LIMIT 100
     """ % (cities[0].lower()))
 
     sparql.setReturnFormat(JSON)

--- a/static/css/Features-Boxed.css
+++ b/static/css/Features-Boxed.css
@@ -68,3 +68,10 @@
   margin-bottom: 20px;
 }
 
+#question_pattern_description {
+    margin-top: 1ex;
+}
+
+#question_pattern_description div {
+    font-style: italic;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,7 +24,7 @@ $(document).ready(function(){
         <div class="container">
             <div class="row">
                 <div class="col-xl-9 mx-auto">
-                    <h2 class="mb-4" data-toggle="popover" title="Popover Header" data-content="Some content inside the popover">Type your query here</h2>
+                    <h2 class="mb-4" data-toggle="popover" title="Popover Header" data-content="Some content inside the popover">Type your question here</h2>
                 </div>
                 <div class="col-md-10 col-lg-8 col-xl-7 mx-auto">
                     <form action="/get_answer" method="POST">

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@ $(document).ready(function(){
                 <div class="col-md-10 col-lg-8 col-xl-7 mx-auto">
                     <form action="/get_answer" method="POST">
                         <div class="form-row">
-                            <div class="col-12 col-md-9 mb-2 mb-md-0"><input class="form-control form-control-lg" name="question_text" type="text" placeholder="How many people living in Los Angeles?"></div>
+                            <div class="col-12 col-md-9 mb-2 mb-md-0"><input class="form-control form-control-lg" name="question_text" type="text" placeholder="How many people live in Los Angeles?"><div id="question_pattern_description">Please start your question with the phrase <div>&quot;How many people live in &quot;</div></div></div>
                             <div class="col-12 col-md-3"><button class="btn btn-primary btn-block btn-lg" type="submit" >Search</button></div>
                         </div>
                     </form>


### PR DESCRIPTION
Feel free to integrate the changes. No pressure.

 * improved secret key to ensure new sessions for new deployments (crucial in case of a session error)
 * improved the query to cover cities which are not of type `dbo:city`, e.g., London (UK)
 * improved application logics to provide more feedback to the user and support the described question pattern
 * changed text to question (query is mostly used for the technical request)
 * changed pattern in correspondence to the backend behavior, added some description
 * improved documentation, w.r.t. the supported pattern and spacy download issues

